### PR TITLE
refactor: refresh token redis적용

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.8'
+services:
+  redis:
+    image: redis:alpine
+    container_name: binbean-redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+    restart: always
+
+volumes:
+  redis-data:
+

--- a/src/main/java/binbean/binbean_BE/auth/JwtTokenProvider.java
+++ b/src/main/java/binbean/binbean_BE/auth/JwtTokenProvider.java
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 @Component
 public class JwtTokenProvider {
@@ -127,6 +128,14 @@ public class JwtTokenProvider {
             logger.error("JWT Exception: ", e);
             throw new JwtException("Invalid JWT token", e); // 일반적인 JWT 오류 예외 던지기
         }
+    }
+
+    /**
+     * refreshToken 토큰 검증
+     * redis에 저장된 토큰을 불러와서 비교
+     */
+    public boolean validateRefreshToken(String refreshToken, String redisRefreshToken) {
+        return StringUtils.hasText(refreshToken) && refreshToken.equals(redisRefreshToken);
     }
 
     // 액세스 토큰 헤더 설정

--- a/src/main/java/binbean/binbean_BE/auth/filter/JwtUsernamePasswordAuthFilter.java
+++ b/src/main/java/binbean/binbean_BE/auth/filter/JwtUsernamePasswordAuthFilter.java
@@ -110,20 +110,6 @@ public class JwtUsernamePasswordAuthFilter extends UsernamePasswordAuthenticatio
         // 헤더에 액세스 토큰 추가
         jwtTokenProvider.setHeaderAccessToken(response, accessToken);
 
-        /** 리프레쉬 토큰을 HttpOnly 쿠키에 저장
-         * 헤더에 직접 리프레쉬 토큰 저장하지 않고 (보안 낮출 가능성 유)
-         * HttpOnly 쿠키를 사용하면 자동으로 요청 시 전달
-         */
-        ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", refreshToken)
-            .httpOnly(true) // 자바스크립트에서 접근 불가능
-            .secure(true) // HTTPS에서만 전송 가능
-            .sameSite("Lax") // CSRF 공격 방지
-            .path("/")
-            .maxAge(jwtTokenProvider.getRefreshExpirationTime())
-            .build();
-
-        response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
-
         // Redis에 Refresh Token 저장 (key = email)
         redisService.setStringValue(userDetails.getUsername(), refreshToken,
             jwtTokenProvider.getRefreshExpirationTime());

--- a/src/main/java/binbean/binbean_BE/auth/filter/JwtUsernamePasswordAuthFilter.java
+++ b/src/main/java/binbean/binbean_BE/auth/filter/JwtUsernamePasswordAuthFilter.java
@@ -17,7 +17,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -112,19 +114,19 @@ public class JwtUsernamePasswordAuthFilter extends UsernamePasswordAuthenticatio
          * 헤더에 직접 리프레쉬 토큰 저장하지 않고 (보안 낮출 가능성 유)
          * HttpOnly 쿠키를 사용하면 자동으로 요청 시 전달
          */
-//        ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", refreshToken)
-//            .httpOnly(true) // 자바스크립트에서 접근 불가능
-//            .secure(true) // HTTPS에서만 전송 가능
-//            .sameSite("Lax") // CSRF 공격 방지
-//            .path("/")
-//            .maxAge(jwtTokenProvider.getRefreshExpirationTime())
-//            .build();
+        ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", refreshToken)
+            .httpOnly(true) // 자바스크립트에서 접근 불가능
+            .secure(true) // HTTPS에서만 전송 가능
+            .sameSite("Lax") // CSRF 공격 방지
+            .path("/")
+            .maxAge(jwtTokenProvider.getRefreshExpirationTime())
+            .build();
 
-//        response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
 
-        // FIXME: Redis에 Refresh Token 저장
-//        redisService.setStringValue(userDetails.getUsername(), refreshToken,
-//            jwtTokenProvider.getRefreshExpirationTime());
+        // Redis에 Refresh Token 저장 (key = email)
+        redisService.setStringValue(userDetails.getUsername(), refreshToken,
+            jwtTokenProvider.getRefreshExpirationTime());
 
         setResponseEncoding(response);
         String jsonResponse = objectMapper.writeValueAsString(tokenDto);

--- a/src/main/java/binbean/binbean_BE/auth/filter/JwtVerificationFilter.java
+++ b/src/main/java/binbean/binbean_BE/auth/filter/JwtVerificationFilter.java
@@ -3,6 +3,7 @@ package binbean.binbean_BE.auth.filter;
 import binbean.binbean_BE.auth.JwtTokenProvider;
 import binbean.binbean_BE.auth.UserDetailsImpl;
 import binbean.binbean_BE.constants.Constants.LoggingMsg;
+import binbean.binbean_BE.infra.RedisService;
 import binbean.binbean_BE.service.AuthService;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
@@ -23,10 +24,13 @@ public class JwtVerificationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final AuthService authService;
+    private final RedisService redisService;
 
-    public JwtVerificationFilter(JwtTokenProvider jwtTokenProvider, AuthService authService) {
+    public JwtVerificationFilter(JwtTokenProvider jwtTokenProvider, AuthService authService,
+        RedisService redisService) {
         this.jwtTokenProvider = jwtTokenProvider;
         this.authService = authService;
+        this.redisService = redisService;
     }
 
     @Override

--- a/src/main/java/binbean/binbean_BE/constants/Constants.java
+++ b/src/main/java/binbean/binbean_BE/constants/Constants.java
@@ -44,5 +44,8 @@ public class Constants {
         public static final String AES_KEY_DECRYPT_ERROR = "AES 기반 복호화 실패";
         public static final String FAVORITE_NOT_FOUND_WITH_USER_AND_CAFE = "즐겨찾기를 찾을 수 없습니다.";
         public static final String CAFE_NOT_FOUND = "해당 카페를 찾을 수 없습니다.";
+        public static final String LOGIN_EXPIRED = "로그인이 만료되었습니다. 다시 로그인해주세요.";
+        public static final String REFRESH_EXPIRED = "리프레시 토큰이 유효하지 않습니다.";
+
     }
 }

--- a/src/main/java/binbean/binbean_BE/controller/AuthController.java
+++ b/src/main/java/binbean/binbean_BE/controller/AuthController.java
@@ -1,13 +1,19 @@
 package binbean.binbean_BE.controller;
 
+import binbean.binbean_BE.auth.JwtTokenProvider;
+import binbean.binbean_BE.dto.auth.TokenDto;
 import binbean.binbean_BE.dto.auth.request.LoginRequest;
 import binbean.binbean_BE.dto.auth.request.RegisterRequest;
 import binbean.binbean_BE.dto.auth.request.SocialLoginRequest;
 import binbean.binbean_BE.service.AuthService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,9 +23,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
+    private final JwtTokenProvider jwtTokenProvider;
 
-    public AuthController(AuthService authService) {
+    public AuthController(AuthService authService, JwtTokenProvider jwtTokenProvider) {
         this.authService = authService;
+        this.jwtTokenProvider = jwtTokenProvider;
     }
 
     @PostMapping("/registration")
@@ -34,5 +42,18 @@ public class AuthController {
 
     @PostMapping("/kakao/login")
     public void socialLogin(@Valid @RequestBody SocialLoginRequest request) {
+    }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<TokenDto> reissue(HttpServletRequest request) {
+        /**
+         * 추후 안드로이드와의 논의 사항
+         * => reissue 요청 시 클라이언트에서 가지고 있는 리프레시 토큰 전송을 헤더를 통해서 할 지
+         * 아니면 별도의 RequestBody를 통해서 할 지 의논 필요
+         */
+        // 헤더에서 리프레시 토큰 추출 (reissue 요청 시 클라이언트에서 추가 헤더 정의하여 리프레시 토큰 전송)
+        String refreshToken = request.getHeader("X-Refresh-Token");
+        TokenDto token = authService.reissue(refreshToken);
+        return ResponseEntity.status(HttpStatus.OK).body(token);
     }
 }

--- a/src/main/java/binbean/binbean_BE/exception/UnauthorizedException.java
+++ b/src/main/java/binbean/binbean_BE/exception/UnauthorizedException.java
@@ -1,0 +1,12 @@
+package binbean.binbean_BE.exception;
+
+import binbean.binbean_BE.constants.Constants.ErrorMsg;
+import org.springframework.http.HttpStatus;
+
+public class UnauthorizedException extends ClientErrorException {
+    public UnauthorizedException() { super(HttpStatus.UNAUTHORIZED, ErrorMsg.REFRESH_EXPIRED); }
+
+    public UnauthorizedException(HttpStatus status, String message) {
+        super(status, message);
+    }
+}

--- a/src/main/java/binbean/binbean_BE/service/AuthService.java
+++ b/src/main/java/binbean/binbean_BE/service/AuthService.java
@@ -1,12 +1,19 @@
 package binbean.binbean_BE.service;
 
+import binbean.binbean_BE.auth.JwtTokenProvider;
 import binbean.binbean_BE.auth.UserDetailsImpl;
+import binbean.binbean_BE.constants.Constants.ErrorMsg;
+import binbean.binbean_BE.dto.auth.TokenDto;
 import binbean.binbean_BE.dto.auth.request.RegisterRequest;
+import binbean.binbean_BE.exception.UnauthorizedException;
 import binbean.binbean_BE.exception.UserAlreadyExistException;
 import binbean.binbean_BE.entity.User;
+import binbean.binbean_BE.infra.RedisService;
 import binbean.binbean_BE.repository.UserRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -19,10 +26,15 @@ public class AuthService implements UserDetailsService {
 
     private final UserRepository userRepository;
     private final BCryptPasswordEncoder passwordEncoder;
+    private final RedisService redisService;
+    private final JwtTokenProvider jwtTokenProvider;
 
-    public AuthService(UserRepository userRepository, BCryptPasswordEncoder passwordEncoder) {
+    public AuthService(UserRepository userRepository, BCryptPasswordEncoder passwordEncoder,
+        RedisService redisService, JwtTokenProvider jwtTokenProvider) {
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
+        this.redisService = redisService;
+        this.jwtTokenProvider = jwtTokenProvider;
     }
 
     @Override
@@ -48,6 +60,34 @@ public class AuthService implements UserDetailsService {
     }
 
     /**
+     * 액세스 토큰 만료 시 회원 검증 후, 리프레쉬 토큰을 검증해서 액세스 토큰과 리프레쉬 토큰을 재발급
+     */
+    public TokenDto reissue(String refreshToken) {
+        // refreshToken 유효성, 만료 검사
+        jwtTokenProvider.validateToken(refreshToken);
+        String username = jwtTokenProvider.getUsername(refreshToken);
+
+        String refreshTokenInRedis = redisService.getValues(username)
+            .orElseThrow(UnauthorizedException::new);
+
+        // redis에 저장된 토큰과 같은지를 비교 (같지 않으면 삭제 및 재로그인 요청)
+        if (!jwtTokenProvider.validateRefreshToken(refreshToken, refreshTokenInRedis)) {
+            redisService.deleteValues(username);
+            throw new UnauthorizedException();
+        }
+
+        // UserDetails 불러와서 토큰 재발급
+        UserDetailsImpl userDetails = (UserDetailsImpl) loadUserByUsername(username);
+        // 액세스 토큰 재발급 및 redis 업데이트
+        redisService.deleteValues(username);
+        var tokenDto = jwtTokenProvider.generateToken(userDetails);
+        // redis에 refresh token 저장
+        redisService.setStringValue(userDetails.getUsername(), tokenDto.getRefreshToken(),
+            jwtTokenProvider.getRefreshExpirationTime());
+        return tokenDto;
+    }
+
+    /**
      * 소셜 로그인일 경우, password를 null로 보냄
      */
     private String encodePassword(String password) {
@@ -61,4 +101,6 @@ public class AuthService implements UserDetailsService {
         return userRepository.findByEmail(email)
             .orElseThrow(() -> new UsernameNotFoundException(email));
     }
+
+
 }


### PR DESCRIPTION
# 🌟 풀 리퀘스트

## 🌐 연관 이슈 번호
- #36 

## 💬 요약
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성 -->
- Refresh Token을 redis에 저장
- Refresh Token 검증 로직 및 Access Token 재발급
- 개발환경 세팅 (docker-compose.yml)

## 💫 타입

- [x] 기능
- [ ] 버그
- [ ] 테스트
- [x] 리팩토링
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제
- [ ] 문서 수정
- [ ] 기타(환경) 
