### PR TITLE
refactor: refresh-token-암호화

### DIFF
--- a/src/main/java/binbean/binbean_BE/auth/JwtTokenProvider.java
+++ b/src/main/java/binbean/binbean_BE/auth/JwtTokenProvider.java
@@ -6,6 +6,7 @@ import binbean.binbean_BE.encryption.AESUtils;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwt;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
@@ -154,5 +155,20 @@ public class JwtTokenProvider {
 
     public long getRefreshExpirationTime() {
         return refreshExpirationTime;
+    }
+
+    /**
+     * 토큰의 남은 유효시간 반환
+     */
+    public long getRemainingValidityTime(String token) {
+        Claims claims = Jwts.parser()
+            .verifyWith(key)
+            .build()
+            .parseSignedClaims(token)
+            .getPayload();
+
+        long exp = claims.getExpiration().getTime();
+        long now = Instant.now().getEpochSecond();
+        return Math.max(exp - now, 0);
     }
 }

--- a/src/main/java/binbean/binbean_BE/auth/JwtTokenProvider.java
+++ b/src/main/java/binbean/binbean_BE/auth/JwtTokenProvider.java
@@ -1,8 +1,10 @@
 package binbean.binbean_BE.auth;
 
 import binbean.binbean_BE.constants.Constants.ErrorMsg;
+import binbean.binbean_BE.constants.Constants.LoggingMsg;
 import binbean.binbean_BE.dto.auth.TokenDto;
 import binbean.binbean_BE.encryption.AESUtils;
+import binbean.binbean_BE.infra.RedisService;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jws;
@@ -15,6 +17,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Date;
+import java.util.Optional;
 import javax.crypto.SecretKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,6 +36,7 @@ public class JwtTokenProvider {
     public static final String AUTHORIZATION = "Authorization";
 
     private final SecretKey key;
+    private final RedisService redisService;
 
     @Value("${jwt.token.access-expiration-time}")
     private long accessExpirationTime;
@@ -40,13 +44,15 @@ public class JwtTokenProvider {
     @Value("${jwt.token.refresh-expiration-time}")
     private long refreshExpirationTime;
 
-    public JwtTokenProvider(@Value("${jwt.secret-key}") String secretKey, AESUtils aesUtils) {
+    public JwtTokenProvider(@Value("${jwt.secret-key}") String secretKey, AESUtils aesUtils,
+        RedisService redisService) {
         try {
             String decryptedSecretKey = aesUtils.decryptWithAesKey(secretKey);
             this.key = Keys.hmacShaKeyFor(decryptedSecretKey.getBytes(StandardCharsets.UTF_8));
         } catch (Exception e) {
             throw new RuntimeException(ErrorMsg.JWT_SECRET_DECRYPT_ERROR, e);
         }
+        this.redisService = redisService;
     }
 
     /**
@@ -170,5 +176,16 @@ public class JwtTokenProvider {
         long exp = claims.getExpiration().getTime();
         long now = Instant.now().getEpochSecond();
         return Math.max(exp - now, 0);
+    }
+
+    /**
+     * 로그아웃을 하였으나 이전에 사용된 액세스 토큰이 아직 유효한 경우,
+     * 로그아웃 시에 레디스에 저장한 액세스 토큰값을 불러와 해당 값이 존재하면 (값이 "logout")
+     * true를 반환
+     * (JWT 토큰의 유효성을 서버에서 강제로 무효화시킬 수 없기에 redis에 따로 저장해두고 요청 시 확인)
+     */
+    public boolean isAccessTokenLogout(String accessToken) {
+        Optional<String> token = redisService.getValues(accessToken);
+        return token.isPresent() && token.get().equals(LoggingMsg.LOGOUT_FLAG);
     }
 }

--- a/src/main/java/binbean/binbean_BE/auth/filter/JwtExceptionFilter.java
+++ b/src/main/java/binbean/binbean_BE/auth/filter/JwtExceptionFilter.java
@@ -2,6 +2,7 @@ package binbean.binbean_BE.auth.filter;
 
 
 import binbean.binbean_BE.exception.ErrorResponse;
+import binbean.binbean_BE.exception.UnauthorizedException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
@@ -25,7 +26,7 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
         HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         try {
             filterChain.doFilter(request, response);
-        } catch (ExpiredJwtException e) {
+        } catch (ExpiredJwtException | UnauthorizedException e) {
             writeResponse(response, HttpStatus.UNAUTHORIZED, e.getMessage());
         } catch (JwtException e) {
             // 기존에 작성했던 jwt auth filter 내부 발생하는 jwt exception이라는 예외가 발생했을 때 캐치해서 처리

--- a/src/main/java/binbean/binbean_BE/auth/filter/JwtUsernamePasswordAuthFilter.java
+++ b/src/main/java/binbean/binbean_BE/auth/filter/JwtUsernamePasswordAuthFilter.java
@@ -6,6 +6,7 @@ import binbean.binbean_BE.constants.Constants.ErrorMsg;
 import binbean.binbean_BE.constants.Constants.URL;
 import binbean.binbean_BE.dto.auth.TokenDto;
 import binbean.binbean_BE.dto.auth.request.LoginRequest;
+import binbean.binbean_BE.encryption.AESUtils;
 import binbean.binbean_BE.exception.ErrorResponse;
 import binbean.binbean_BE.infra.RedisService;
 import binbean.binbean_BE.service.AuthService;
@@ -17,6 +18,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
@@ -43,14 +45,20 @@ public class JwtUsernamePasswordAuthFilter extends UsernamePasswordAuthenticatio
     private final JwtTokenProvider jwtTokenProvider;
     private final AuthService authService;
     private final RedisService redisService;
+    private final AESUtils aesUtils;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
+    @Value("${aes.key}")
+    private static String encryptedAesKey;
+
     public JwtUsernamePasswordAuthFilter(AuthenticationManager authenticationManager,
-        AuthService authService, JwtTokenProvider jwtTokenProvider, RedisService redisService) {
+        AuthService authService, JwtTokenProvider jwtTokenProvider, RedisService redisService,
+        AESUtils aesUtils) {
         this.authenticationManager = authenticationManager;
         this.jwtTokenProvider = jwtTokenProvider;
         this.authService = authService;
         this.redisService = redisService;
+        this.aesUtils = aesUtils;
     }
 
     /**
@@ -106,18 +114,21 @@ public class JwtUsernamePasswordAuthFilter extends UsernamePasswordAuthenticatio
         TokenDto tokenDto = jwtTokenProvider.generateToken(userDetails);
         String accessToken = tokenDto.getAccessToken();
         String refreshToken = tokenDto.getRefreshToken();
+        String encryptedRefreshToken = aesUtils.encryptWithAesKey(refreshToken);
+        tokenDto.setEncryptedRefreshToken(encryptedRefreshToken);
 
         // 헤더에 액세스 토큰 추가
         jwtTokenProvider.setHeaderAccessToken(response, accessToken);
 
         // Redis에 Refresh Token 저장 (key = email)
-        redisService.setStringValue(userDetails.getUsername(), refreshToken,
+        redisService.setStringValue(userDetails.getUsername(), encryptedRefreshToken,
             jwtTokenProvider.getRefreshExpirationTime());
 
         setResponseEncoding(response);
         String jsonResponse = objectMapper.writeValueAsString(tokenDto);
         response.getWriter().write(jsonResponse);
     }
+
     private void setErrorResponse(HttpServletResponse response, HttpStatus status, String message) {
         response.setStatus(status.value());
         setResponseEncoding(response);

--- a/src/main/java/binbean/binbean_BE/auth/filter/JwtUsernamePasswordAuthFilter.java
+++ b/src/main/java/binbean/binbean_BE/auth/filter/JwtUsernamePasswordAuthFilter.java
@@ -114,14 +114,13 @@ public class JwtUsernamePasswordAuthFilter extends UsernamePasswordAuthenticatio
         TokenDto tokenDto = jwtTokenProvider.generateToken(userDetails);
         String accessToken = tokenDto.getAccessToken();
         String refreshToken = tokenDto.getRefreshToken();
-        String encryptedRefreshToken = aesUtils.encryptWithAesKey(refreshToken);
-        tokenDto.setEncryptedRefreshToken(encryptedRefreshToken);
+        tokenDto.setEncryptedRefreshToken(aesUtils.encryptWithAesKey(refreshToken));
 
         // 헤더에 액세스 토큰 추가
         jwtTokenProvider.setHeaderAccessToken(response, accessToken);
 
         // Redis에 Refresh Token 저장 (key = email)
-        redisService.setStringValue(userDetails.getUsername(), encryptedRefreshToken,
+        redisService.setStringValue(userDetails.getUsername(), tokenDto.getRefreshToken(),
             jwtTokenProvider.getRefreshExpirationTime());
 
         setResponseEncoding(response);

--- a/src/main/java/binbean/binbean_BE/auth/filter/JwtVerificationFilter.java
+++ b/src/main/java/binbean/binbean_BE/auth/filter/JwtVerificationFilter.java
@@ -2,7 +2,9 @@ package binbean.binbean_BE.auth.filter;
 
 import binbean.binbean_BE.auth.JwtTokenProvider;
 import binbean.binbean_BE.auth.UserDetailsImpl;
+import binbean.binbean_BE.constants.Constants.ErrorMsg;
 import binbean.binbean_BE.constants.Constants.LoggingMsg;
+import binbean.binbean_BE.exception.UnauthorizedException;
 import binbean.binbean_BE.infra.RedisService;
 import binbean.binbean_BE.service.AuthService;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -12,6 +14,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -52,6 +55,12 @@ public class JwtVerificationFilter extends OncePerRequestFilter {
 
             // 유효한 토큰인지 검사 (유효하지 않으면 예외 발생)
             jwtTokenProvider.validateToken(accessToken);
+
+            // 로그아웃 이후에도 유효한 액세스 토큰인지 검사 (예외)
+            if (jwtTokenProvider.isAccessTokenLogout(accessToken)) {
+                throw new UnauthorizedException(HttpStatus.UNAUTHORIZED, ErrorMsg.LOGIN_EXPIRED);
+            }
+
             var username = jwtTokenProvider.getUsername(accessToken);
             var userDetails = authService.loadUserByUsername(username);
             // 액세스토큰 값이 유효하면 setAuthentication 통해 securityContext에 인증 정보 저장

--- a/src/main/java/binbean/binbean_BE/auth/filter/JwtVerificationFilter.java
+++ b/src/main/java/binbean/binbean_BE/auth/filter/JwtVerificationFilter.java
@@ -47,7 +47,6 @@ public class JwtVerificationFilter extends OncePerRequestFilter {
             filterChain.doFilter(request, response);
             return;
         }
-
         try {
             var securityContext = SecurityContextHolder.getContext();
 

--- a/src/main/java/binbean/binbean_BE/auth/filter/JwtVerificationFilter.java
+++ b/src/main/java/binbean/binbean_BE/auth/filter/JwtVerificationFilter.java
@@ -27,13 +27,10 @@ public class JwtVerificationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final AuthService authService;
-    private final RedisService redisService;
 
-    public JwtVerificationFilter(JwtTokenProvider jwtTokenProvider, AuthService authService,
-        RedisService redisService) {
+    public JwtVerificationFilter(JwtTokenProvider jwtTokenProvider, AuthService authService) {
         this.jwtTokenProvider = jwtTokenProvider;
         this.authService = authService;
-        this.redisService = redisService;
     }
 
     @Override

--- a/src/main/java/binbean/binbean_BE/config/SecurityConfig.java
+++ b/src/main/java/binbean/binbean_BE/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import binbean.binbean_BE.auth.filter.JwtUsernamePasswordAuthFilter;
 import binbean.binbean_BE.auth.filter.JwtVerificationFilter;
 import binbean.binbean_BE.auth.filter.UrlBasedAuthenticationFilter;
 import binbean.binbean_BE.constants.Constants.URL;
+import binbean.binbean_BE.encryption.AESUtils;
 import binbean.binbean_BE.infra.RedisService;
 import binbean.binbean_BE.service.AuthService;
 import java.util.List;
@@ -38,16 +39,21 @@ public class SecurityConfig {
     private final JwtExceptionFilter jwtExceptionFilter;
     private final AuthService authService;
     private final RedisService redisService;
+    private final AESUtils aesUtils;
 
     // AuthenticationManager의 Bean을 얻기 위한 authConfiguration 객체
     private final AuthenticationConfiguration authenticationConfiguration;
 
-    public SecurityConfig(JwtVerificationFilter jwtVerificationFilter, JwtExceptionFilter jwtExceptionFilter, AuthService authService,  AuthenticationConfiguration authenticationConfiguration, RedisService redisService) {
+    public SecurityConfig(JwtVerificationFilter jwtVerificationFilter,
+        JwtExceptionFilter jwtExceptionFilter, AuthService authService,
+        AuthenticationConfiguration authenticationConfiguration,
+        RedisService redisService, AESUtils aesUtils) {
         this.jwtVerificationFilter = jwtVerificationFilter;
         this.jwtExceptionFilter = jwtExceptionFilter;
         this.authService = authService;
         this.redisService = redisService;
         this.authenticationConfiguration = authenticationConfiguration;
+        this.aesUtils = aesUtils;
     }
 
     /**
@@ -61,7 +67,7 @@ public class SecurityConfig {
     @Bean
     public JwtUsernamePasswordAuthFilter jwtUsernamePasswordAuthFilter(AuthenticationManager authenticationManager, JwtTokenProvider jwtTokenProvider, RedisService redisService)
         throws Exception {
-        var filter = new JwtUsernamePasswordAuthFilter(authenticationManager, authService, jwtTokenProvider, redisService);
+        var filter = new JwtUsernamePasswordAuthFilter(authenticationManager, authService, jwtTokenProvider, redisService, aesUtils);
         filter.setAuthenticationManager(authenticationManager());
         return filter;
     }
@@ -93,11 +99,11 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtTokenProvider jwtTokenProvider) throws Exception {
         // 일반 로그인 필터 (일반 로그인 경로에만 적용)
-        JwtUsernamePasswordAuthFilter loginFilter = new JwtUsernamePasswordAuthFilter(authenticationManager(), authService, jwtTokenProvider, redisService);
+        JwtUsernamePasswordAuthFilter loginFilter = new JwtUsernamePasswordAuthFilter(authenticationManager(), authService, jwtTokenProvider, redisService, aesUtils);
         loginFilter.setFilterProcessesUrl(URL.NORMAL_LOGIN_URL);
 
         // 카카오 로그인 필터 (카카오 로그인 경로에만 적용)
-        JwtUsernamePasswordAuthFilter socialLoginFilter = new JwtUsernamePasswordAuthFilter(authenticationManager(), authService, jwtTokenProvider, redisService);
+        JwtUsernamePasswordAuthFilter socialLoginFilter = new JwtUsernamePasswordAuthFilter(authenticationManager(), authService, jwtTokenProvider, redisService, aesUtils);
         socialLoginFilter.setFilterProcessesUrl(URL.KAKAO_LOGIN_URL);
 
         // OncePerRequestFilter 등록하여 경로에 따라 필터를 분기 처리

--- a/src/main/java/binbean/binbean_BE/constants/Constants.java
+++ b/src/main/java/binbean/binbean_BE/constants/Constants.java
@@ -26,6 +26,7 @@ public class Constants {
 
     public static class LoggingMsg {
         public static final String ACCESS_TOKEN_MISSING = "Access token is missing in request: ";
+        public static final String LOGOUT_FLAG = "logout";
     }
 
     public static class ErrorMsg {
@@ -46,6 +47,5 @@ public class Constants {
         public static final String CAFE_NOT_FOUND = "해당 카페를 찾을 수 없습니다.";
         public static final String LOGIN_EXPIRED = "로그인이 만료되었습니다. 다시 로그인해주세요.";
         public static final String REFRESH_EXPIRED = "리프레시 토큰이 유효하지 않습니다.";
-
     }
 }

--- a/src/main/java/binbean/binbean_BE/controller/AuthController.java
+++ b/src/main/java/binbean/binbean_BE/controller/AuthController.java
@@ -8,6 +8,7 @@ import binbean.binbean_BE.dto.auth.request.SocialLoginRequest;
 import binbean.binbean_BE.service.AuthService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.StringUtils;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -38,6 +40,15 @@ public class AuthController {
 
     @PostMapping("/login")
     public void login(@Valid @RequestBody LoginRequest request) {
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(HttpServletRequest request) {
+        // 헤더에서 액세스 토큰/리프레시 토큰 추출 (logout 요청 시 클라이언트에서 추가 헤더 정의하여 리프레시 토큰 전송)
+        String accessToken = jwtTokenProvider.getHeaderAccessToken(request);
+        String refreshToken = request.getHeader("X-Refresh-Token");
+        authService.logout(accessToken, refreshToken);
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
     @PostMapping("/kakao/login")

--- a/src/main/java/binbean/binbean_BE/dto/auth/TokenDto.java
+++ b/src/main/java/binbean/binbean_BE/dto/auth/TokenDto.java
@@ -10,4 +10,8 @@ public class TokenDto {
     private String accessToken;
     private String refreshToken;
     private String authType;
+
+    public void setEncryptedRefreshToken(String encryptedRefreshToken) {
+        this.refreshToken = encryptedRefreshToken;
+    }
 }

--- a/src/main/java/binbean/binbean_BE/service/AuthService.java
+++ b/src/main/java/binbean/binbean_BE/service/AuthService.java
@@ -3,6 +3,7 @@ package binbean.binbean_BE.service;
 import binbean.binbean_BE.auth.JwtTokenProvider;
 import binbean.binbean_BE.auth.UserDetailsImpl;
 import binbean.binbean_BE.constants.Constants.ErrorMsg;
+import binbean.binbean_BE.constants.Constants.LoggingMsg;
 import binbean.binbean_BE.dto.auth.TokenDto;
 import binbean.binbean_BE.dto.auth.request.RegisterRequest;
 import binbean.binbean_BE.encryption.AESUtils;
@@ -121,8 +122,9 @@ public class AuthService implements UserDetailsService {
         redisService.deleteValues(username);
 
         // 사용자가 로그아웃했음을 기록하기 위해 Access Token을 Redis에 저장
+        // redis의 TTL 기능에 의해 Access Token의 유효시간이 만료되면 자동으로 redis에서 삭제됨
         long expTime = jwtTokenProvider.getRemainingValidityTime(accessToken);
-        redisService.setStringValue(accessToken, "logout", expTime);
+        redisService.setStringValue(accessToken, LoggingMsg.LOGOUT_FLAG, expTime);
     }
 
     /**

--- a/src/main/java/binbean/binbean_BE/service/AuthService.java
+++ b/src/main/java/binbean/binbean_BE/service/AuthService.java
@@ -5,6 +5,7 @@ import binbean.binbean_BE.auth.UserDetailsImpl;
 import binbean.binbean_BE.constants.Constants.ErrorMsg;
 import binbean.binbean_BE.dto.auth.TokenDto;
 import binbean.binbean_BE.dto.auth.request.RegisterRequest;
+import binbean.binbean_BE.encryption.AESUtils;
 import binbean.binbean_BE.exception.UnauthorizedException;
 import binbean.binbean_BE.exception.UserAlreadyExistException;
 import binbean.binbean_BE.entity.User;
@@ -28,13 +29,15 @@ public class AuthService implements UserDetailsService {
     private final BCryptPasswordEncoder passwordEncoder;
     private final RedisService redisService;
     private final JwtTokenProvider jwtTokenProvider;
+    private final AESUtils aesUtils;
 
     public AuthService(UserRepository userRepository, BCryptPasswordEncoder passwordEncoder,
-        RedisService redisService, JwtTokenProvider jwtTokenProvider) {
+        RedisService redisService, JwtTokenProvider jwtTokenProvider, AESUtils aesUtils) {
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
         this.redisService = redisService;
         this.jwtTokenProvider = jwtTokenProvider;
+        this.aesUtils = aesUtils;
     }
 
     @Override
@@ -60,15 +63,18 @@ public class AuthService implements UserDetailsService {
     }
 
     /**
-     * 액세스 토큰 만료 시 회원 검증 후, 리프레쉬 토큰을 검증해서 액세스 토큰과 리프레쉬 토큰을 재발급
+     * 액세스 토큰 만료 시 회원 검증 후, 전달받은 암호화된 리프레쉬 토큰을 복호화/검증해서 액세스 토큰과 리프레쉬 토큰을 재발급
      */
-    public TokenDto reissue(String refreshToken) {
+    public TokenDto reissue(String encryptedRefreshToken) {
+        // refreshToken 복호화
+        String refreshToken = aesUtils.decryptWithAesKey(encryptedRefreshToken);
+
         // refreshToken 유효성, 만료 검사
         jwtTokenProvider.validateToken(refreshToken);
         String username = jwtTokenProvider.getUsername(refreshToken);
 
-        String refreshTokenInRedis = redisService.getValues(username)
-            .orElseThrow(UnauthorizedException::new);
+        String refreshTokenInRedis = aesUtils.decryptWithAesKey(redisService.getValues(username)
+            .orElseThrow(UnauthorizedException::new));
 
         // redis에 저장된 토큰과 같은지를 비교 (같지 않으면 삭제 및 재로그인 요청)
         if (!jwtTokenProvider.validateRefreshToken(refreshToken, refreshTokenInRedis)) {
@@ -81,6 +87,9 @@ public class AuthService implements UserDetailsService {
         // 액세스 토큰 재발급 및 redis 업데이트
         redisService.deleteValues(username);
         var tokenDto = jwtTokenProvider.generateToken(userDetails);
+        // 새로 갱신된 refresh token 암호화
+        tokenDto.setEncryptedRefreshToken(aesUtils.encryptWithAesKey(refreshToken));
+
         // redis에 refresh token 저장
         redisService.setStringValue(userDetails.getUsername(), tokenDto.getRefreshToken(),
             jwtTokenProvider.getRefreshExpirationTime());
@@ -101,6 +110,4 @@ public class AuthService implements UserDetailsService {
         return userRepository.findByEmail(email)
             .orElseThrow(() -> new UsernameNotFoundException(email));
     }
-
-
 }

--- a/src/main/java/binbean/binbean_BE/service/AuthService.java
+++ b/src/main/java/binbean/binbean_BE/service/AuthService.java
@@ -97,6 +97,35 @@ public class AuthService implements UserDetailsService {
     }
 
     /**
+     * 사용자가 로그아웃한 후에도, Access Token을 다시 사용해서 요청을 보낼 가능성이 있음
+     * 그리하여 Redis에서 "logout" 값이 있으면, 해당 토큰은 더 이상 사용할 수 없도록 체크
+     * 로그아웃 후 기존 Access Token이 유효해도 사용 불가 (로그아웃된 토큰 차단)
+     * 키 : accessToken, 값: "logout"
+     */
+    public void logout(String accessToken, String encryptedRefreshToken) {
+        // 액세스 토큰 유효성 검사
+        jwtTokenProvider.validateToken(accessToken);
+        String username = jwtTokenProvider.getUsername(accessToken);
+
+        // refresh token 복호화 및 redis에서 조회
+        String refreshToken = aesUtils.decryptWithAesKey(encryptedRefreshToken);
+        String refreshTokenInRedis = aesUtils.decryptWithAesKey(redisService.getValues(username)
+            .orElseThrow(UnauthorizedException::new));
+
+        // 요청받은 refreshToken과 레디스에 저장된 refreshToken이 동일한지 추가 검증
+        if (!refreshToken.equals(refreshTokenInRedis)) {
+            throw new UnauthorizedException();
+        }
+
+        // redis에 저장되어있는 refreshToken 삭제 (로그아웃 후 더 이상 재발급 요청 불가)
+        redisService.deleteValues(username);
+
+        // 사용자가 로그아웃했음을 기록하기 위해 Access Token을 Redis에 저장
+        long expTime = jwtTokenProvider.getRemainingValidityTime(accessToken);
+        redisService.setStringValue(accessToken, "logout", expTime);
+    }
+
+    /**
      * 소셜 로그인일 경우, password를 null로 보냄
      */
     private String encodePassword(String password) {


### PR DESCRIPTION
# 🌟 풀 리퀘스트

## 🌐 연관 이슈 번호
- #40 

## 💬 요약
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성 -->
- 로그인 시 refresh token 암호화하여 redis 저장 및 리스폰스 응답
- reissue api 호출 시, 암호화된 리프레쉬 토큰을 받아서 복호화하여 검증 수행하도록 수정
- 로그아웃 기능
- 로그아웃 이후에도 액세스 토큰이 유효해서 통신이 요청 가능해지는 상황 차단

## 💫 타입

- [x] 기능
- [ ] 버그
- [ ] 테스트
- [x] 리팩토링
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제
- [ ] 문서 수정
- [ ] 기타(환경) 
